### PR TITLE
Add a request macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,9 +144,9 @@ class TransformValue implements Transformable
     }
 }
 
-$input = ['first_name'=>' Bob'];
+$input = ['first_name' => ' Bob'];
 $transformers = [
-    'first_name'=>['trim', new TransformValue],
+    'first_name' => ['trim', new TransformValue],
 ];
 $transformer = new DataTransformer($input, $transformers);
 $transformer->transform();
@@ -329,6 +329,31 @@ class ExampleController extends Controller
 }
 
 ```
+
+### Use the Request macro
+
+You can also utilize a macro on a `Illuminate\Http\Request` object instance by calling the `transform()` function on the request itself, returning the resulting transform.
+
+```php
+public function store(Request $request)
+{
+    // Using the data that is in the request object (i.e. `$request->all()`)
+    $transformedData = $request->transform([
+        'first_name' => ['strtoupper'],
+    ]);
+
+    // $transformedData['first_name'] will be all uppercase
+    // all other data will be included from the request
+    
+    // You can also customize the input that is transformed,
+    // in this case $transformedData will only have the `first_name` key.
+    $transformedData = $request->transform($request->only(['first_name'], [
+        'first_name' => ['strtoupper'],
+    ]);
+}
+```
+
+If calling on a `FormRequest` object, it will use the `validated()` function to retrieve the input data.
 
 ## Contribute
 

--- a/README.md
+++ b/README.md
@@ -355,6 +355,18 @@ public function store(Request $request)
 
 If calling on a `FormRequest` object, it will use the `validated()` function to retrieve the input data.
 
+If you don't want to include the macro, you can ignore package discovery for the service provider by including the following in your `composer.json`.
+
+```
+"extra": {
+    "laravel": {
+        "dont-discover": [
+            "surgiie/transformer"
+        ]
+    }
+},
+```
+
 ## Contribute
 
 Contributions are always welcome in the following manner:

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
     ],
     "require": {
         "php": "^8.0.2",
+        "illuminate/http": "^9.0",
         "illuminate/support": "^9.0",
         "illuminate/validation": "^9.0"
     },
@@ -42,6 +43,13 @@
     "config": {
         "allow-plugins": {
             "pestphp/pest-plugin": true
+        }
+    },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "Surgiie\\Transformer\\TransformerServiceProvider"
+            ]
         }
     }
 }

--- a/src/TransformerServiceProvider.php
+++ b/src/TransformerServiceProvider.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Surgiie\Transformer;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\ServiceProvider;
+
+class TransformerServiceProvider extends ServiceProvider
+{
+    public function boot()
+    {
+        Request::macro('transform', function (array $input, array $transformers = null): array {
+            $localTransformers = $transformers ?? $input;
+            $input = is_null($transformers)
+                ? (method_exists($this, 'validated')
+                    ? $this->validated()
+                    : $this->all())
+                : $input;
+
+            return (new DataTransformer($input, $localTransformers))
+                ->transform();
+        });
+    }
+}

--- a/tests/Feature/RequestMacroTest.php
+++ b/tests/Feature/RequestMacroTest.php
@@ -1,0 +1,96 @@
+<?php
+
+use Carbon\Carbon;
+use Surgiie\Transformer\Contracts\Transformable;
+use Surgiie\Transformer\DataTransformer;
+use Surgiie\Transformer\Exceptions\NotCallableException;
+use Surgiie\Transformer\Transformer;
+use function PHPUnit\Framework\greaterThan;
+
+beforeEach(function () {
+    Transformer::unguard();
+    // This is kind of a dirty way to add the macro
+    // without including orchestra/testbench
+    (new \Surgiie\Transformer\TransformerServiceProvider(''))
+        ->boot();
+
+    $this->data = [
+        'first_name' => '    jim    ',
+        'last_name' => '   thompson',
+        'date_of_birth' => '2020-05-24',
+        'password' => 'abcdefgh12345',
+        'favorite_number' => '24',
+        'favorite_date' => null,
+        'get_notifications' => true,
+        'contact_info' => [
+            'address_one' => '123 some lane street',
+            'home_phone' => '1234567890',
+            'cell_phone' => '1234567890',
+            'apartment_number' => '12',
+            'email' => 'email@example.com',
+        ],
+    ];
+
+    $this->request = (new \Illuminate\Http\Request())
+        ->merge($this->data);
+});
+
+it('calls transform on manual data', function () {
+    $transformedData = $this->request->transform(
+        ['not_included_in_request' => '    jim    '],
+        ['not_included_in_request' => 'trim|ucfirst']
+    );
+
+    expect(count($transformedData))->toBe(1)
+        ->and($transformedData['not_included_in_request'])->toBe('Jim');
+});
+
+it('calls transform on request data and includes everything', function () {
+    $transformedData = $this->request->transform(
+        ['first_name' => 'trim|ucfirst']
+    );
+
+    expect(count($transformedData))->toBeGreaterThan(1)
+        ->and($transformedData['first_name'])->toBe('Jim');
+});
+
+it('can specify value order', function () {
+    $formattedData = $this->request->transform([
+        'password' => 'trim|preg_replace:/[^0-9]/,,:value:',
+    ]);
+    expect($formattedData['password'])->toBe('12345')
+        ->and($formattedData['password'])->not->toBe($this->data['password']);
+});
+
+it('can process callbacks', function () {
+    $formattedData = $this->request->transform([
+        'get_notifications' => function () {
+            return 'Never';
+        },
+    ]);
+
+    expect($formattedData['get_notifications'])->toBe('Never')
+        ->and($formattedData['get_notifications'])->not->toBe($this->data['get_notifications']);
+
+});
+
+it('can use inline function and delegate', function () {
+    function to_carbon($value) {
+        return new \Carbon\Carbon($value);
+    }
+    $formattedData = $this->request->transform([
+        'date_of_birth' => 'to_carbon|->addDay:1|->format:m/d/y',
+    ]);
+
+    expect($formattedData['date_of_birth'])->not->toBe('05/24/2020');
+});
+
+it('can use the validated data from form requests', function () {
+    $this->request = (new \Surgiie\Transformer\Tests\SampleFormRequest())
+        ->merge($this->data);
+
+    $transformedData = $this->request->transform(['first_name' => 'trim|ucfirst']);
+
+    expect(count($transformedData))->toBe(1)
+        ->and($transformedData['first_name'])->toBe('Jim');
+});

--- a/tests/SampleFormRequest.php
+++ b/tests/SampleFormRequest.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Surgiie\Transformer\Tests;
+
+use Illuminate\Http\Request;
+
+class SampleFormRequest extends Request
+{
+    public function validated(): array
+    {
+        return $this->only(['first_name']);
+    }
+}


### PR DESCRIPTION
This adds a request macro that can be used to transform the underlying request data. It cuts out some of the extra syntax and transforms the request data.

If you choose to merge this, it would be super helpful for you to add the `hacktoberfest-accepted` tag!